### PR TITLE
Fix script assignmenets

### DIFF
--- a/Scenes/main.tscn
+++ b/Scenes/main.tscn
@@ -1,28 +1,12 @@
 [gd_scene load_steps=5 format=3 uid="uid://th5im2tyeqpe"]
 
+[ext_resource type="Script" path="res://scripts/main.gd" id="1_6yiop"]
 [ext_resource type="PackedScene" uid="uid://cvo70qd07iu1" path="res://Others/tile_map.tscn" id="3_o2ad6"]
 [ext_resource type="PackedScene" uid="uid://cgfy0pt7ei1hk" path="res://Scenes/player.tscn" id="3_t25w5"]
-[ext_resource type="Script" path="res://scripts/Camera2D.gd" id="4_k6efe"]
-
-[sub_resource type="GDScript" id="GDScript_pv26n"]
-script/source = "extends Node2D
-
-var hud_enabled = true
-#const maze = preload(\"res://Scenes/main.tscn\")
-
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	#ProjectSettings.set(\"display/window/size/viewport_width\", 800)
-	#ProjectSettings.set(\"display/window/size/viewport_height\", 600)
-	pass
-
-func on_fringe_changed():
-	$CanvasLayer/spots_visited_column.text = \"\\n\".join(Globals.letters_to_show)
-"
+[ext_resource type="Script" path="res://scripts/Camera2D.gd" id="4_451mq"]
 
 [node name="main" type="Node2D"]
-position = Vector2(160, 60)
-script = SubResource("GDScript_pv26n")
+script = ExtResource("1_6yiop")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 offset_left = -416.0
@@ -35,6 +19,8 @@ color = Color(0.403922, 0.403922, 0.403922, 1)
 [node name="TileMap" parent="." instance=ExtResource("3_o2ad6")]
 position = Vector2(0, -3)
 scale = Vector2(0.5, 0.5)
+y_dim = 35
+x_dim = 35
 
 [node name="Player" parent="." instance=ExtResource("3_t25w5")]
 position = Vector2(25, 22)
@@ -44,4 +30,4 @@ movement_speed = 75
 color = Color(0, 0, 0, 1)
 
 [node name="Camera2D" type="Camera2D" parent="." groups=["maze_cam"]]
-script = ExtResource("4_k6efe")
+script = ExtResource("4_451mq")

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=27 format=3 uid="uid://cgfy0pt7ei1hk"]
 
-[ext_resource type="Script" path="res://scripts/player.gd" id="1_lgkg8"]
+[ext_resource type="Script" path="res://scripts/player.gd" id="1_l2jk1"]
 [ext_resource type="Texture2D" uid="uid://bvqkhch1217gh" path="res://Others/facing-direction-arrow.png" id="3_2ukx6"]
 [ext_resource type="Texture2D" uid="uid://brlrh4oyax1y5" path="res://Others/light-texture.png" id="3_koq8t"]
 
@@ -231,8 +231,7 @@ graph_offset = Vector2(-37, 2)
 [node name="Player" type="CharacterBody2D"]
 position = Vector2(137, 102)
 scale = Vector2(0.6, 0.6)
-script = ExtResource("1_lgkg8")
-movement_speed = 350
+script = ExtResource("1_l2jk1")
 
 [node name="PointLight2D" type="PointLight2D" parent="."]
 energy = 0.8

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -2,13 +2,13 @@ class_name Player # For easier reference to player later on
 extends CharacterBody2D
 
 
-@export var movement_speed = 200
+@export var movement_speed: float = 200
 
-@onready var animation_tree = $AnimationTree # To apply new animations
-@onready var player_camera = $Camera2D
-@onready var maze_camera = get_tree().get_first_node_in_group("maze_cam")
+@onready var animation_tree: AnimationTree = $AnimationTree # To apply new animations
+@onready var player_camera: Camera2D = $Camera2D
+@onready var maze_camera: Camera2D = get_tree().get_first_node_in_group("maze_cam")
 
-var active = true # To deactivate the player when necessary
+var active: bool = true # To deactivate the player when necessary
 var direction: Vector2 = Vector2.ZERO
 
 func _process(delta):


### PR DESCRIPTION
+ Unassign and reassign every script to the repective previously assigned node

Notes: It seems to have fixed the issue thus far, I have applied to some code to the player to ensure that the engine does not bark about errors. So far no errors popping up all is good.

# IMPORTANT
### If you had any script tabs open in the scripting window of the project, make sure to close all of them, and open them anew from the scripts/ folder. Cause you might have scripts open that no longer used and godot being buggy with this as it is, will try to create them in your files or something alike because it thinks they exist or should exist since you are editing in them. If you followed these instructions correctly you should no longer have any issues with the class such as the previous one
- Parser Error: Class Player hides a global script class.