### PR TITLE
Add main menu and options menu

### DIFF
--- a/Scenes/ui_menus/options_main_menu.tscn
+++ b/Scenes/ui_menus/options_main_menu.tscn
@@ -1,0 +1,120 @@
+[gd_scene load_steps=4 format=3 uid="uid://gvc8d20u5h0j"]
+
+[ext_resource type="Script" path="res://scripts/options_main_menu.gd" id="1_d2si5"]
+[ext_resource type="PackedScene" uid="uid://be3ylree1dixi" path="res://Scenes/ui_menus/start_main_menu.tscn" id="2_q7emk"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_fh7a2"]
+font_size = 32
+outline_size = 10
+outline_color = Color(0, 0, 0, 1)
+
+[node name="OptionsMainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_d2si5")
+start_main_menu = ExtResource("2_q7emk")
+
+[node name="BackToMainMenuButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 128.0
+offset_top = -95.0
+offset_right = 288.0
+offset_bottom = -64.0
+grow_vertical = 0
+text = "Back"
+
+[node name="SoundsCheckBox" type="CheckBox" parent="."]
+layout_mode = 0
+offset_left = 128.0
+offset_top = 64.0
+offset_right = 152.0
+offset_bottom = 88.0
+scale = Vector2(3, 3)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 8
+theme_override_font_sizes/font_size = 24
+button_pressed = true
+
+[node name="SoundsLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 200.0
+offset_top = 76.0
+offset_right = 486.0
+offset_bottom = 124.0
+text = "Sound Effects: OFF"
+label_settings = SubResource("LabelSettings_fh7a2")
+
+[node name="SoundsVolumeHSlider" type="HSlider" parent="."]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -400.0
+offset_top = 92.0
+offset_right = -80.0
+offset_bottom = 108.0
+grow_horizontal = 0
+max_value = 7.0
+value = 3.0
+
+[node name="SoundsVolumeLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 592.0
+offset_top = 44.0
+offset_right = 878.0
+offset_bottom = 92.0
+text = "Volume: 0 / 7"
+label_settings = SubResource("LabelSettings_fh7a2")
+
+[node name="MusicCheckBox" type="CheckBox" parent="."]
+layout_mode = 0
+offset_left = 128.0
+offset_top = 136.0
+offset_right = 152.0
+offset_bottom = 160.0
+scale = Vector2(3, 3)
+button_pressed = true
+
+[node name="MusicLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 200.0
+offset_top = 148.0
+offset_right = 486.0
+offset_bottom = 196.0
+text = "Music: OFF"
+label_settings = SubResource("LabelSettings_fh7a2")
+
+[node name="MusicVolumeHSlider" type="HSlider" parent="."]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -400.0
+offset_top = 164.0
+offset_right = -80.0
+offset_bottom = 180.0
+grow_horizontal = 0
+max_value = 7.0
+value = 3.0
+
+[node name="MusicVolumeLabel" type="Label" parent="."]
+layout_mode = 0
+offset_left = 592.0
+offset_top = 116.0
+offset_right = 878.0
+offset_bottom = 164.0
+text = "Volume: 0 / 7"
+label_settings = SubResource("LabelSettings_fh7a2")
+
+[connection signal="pressed" from="BackToMainMenuButton" to="." method="_on_back_to_main_menu_button_pressed"]
+[connection signal="toggled" from="SoundsCheckBox" to="." method="_on_sounds_check_box_toggled"]
+[connection signal="value_changed" from="SoundsVolumeHSlider" to="." method="_on_sounds_volume_h_slider_value_changed"]
+[connection signal="toggled" from="MusicCheckBox" to="." method="_on_music_check_box_toggled"]
+[connection signal="value_changed" from="MusicVolumeHSlider" to="." method="_on_music_volume_h_slider_value_changed"]

--- a/Scenes/ui_menus/start_main_menu.tscn
+++ b/Scenes/ui_menus/start_main_menu.tscn
@@ -1,0 +1,86 @@
+[gd_scene load_steps=4 format=3 uid="uid://be3ylree1dixi"]
+
+[ext_resource type="Script" path="res://scripts/start_menu.gd" id="1_d2v6s"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_5pthy"]
+font_size = 48
+outline_size = 16
+outline_color = Color(0, 0, 0, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_3sfkp"]
+font_size = 20
+font_color = Color(1, 1, 0, 1)
+outline_size = 6
+outline_color = Color(0, 0, 0, 1)
+
+[node name="StartMainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_d2v6s")
+
+[node name="StartButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 120.0
+offset_right = 440.0
+offset_bottom = 53.0
+grow_vertical = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 10
+theme_override_font_sizes/font_size = 32
+text = "Start game"
+
+[node name="OptionsButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 120.0
+offset_top = 64.0
+offset_right = 440.0
+offset_bottom = 117.0
+grow_vertical = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 10
+theme_override_font_sizes/font_size = 32
+text = "Options"
+icon_alignment = 1
+
+[node name="GameNameLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -275.5
+offset_top = 64.0
+offset_right = 275.5
+offset_bottom = 134.0
+grow_horizontal = 2
+text = "LEGOLAS OF LEGENDS 2"
+label_settings = SubResource("LabelSettings_5pthy")
+
+[node name="WarningLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -440.0
+offset_right = -120.0
+offset_bottom = 117.0
+grow_horizontal = 0
+grow_vertical = 2
+text = "Warning:
+The game contains flashing lights & irritating sound effects"
+label_settings = SubResource("LabelSettings_3sfkp")
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+
+[connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="OptionsButton" to="." method="_on_options_button_pressed"]

--- a/Scripts/options_main_menu.gd
+++ b/Scripts/options_main_menu.gd
@@ -1,0 +1,59 @@
+extends Control
+
+@export var start_main_menu: PackedScene
+
+@onready var sounds_check_box: CheckBox = $SoundsCheckBox
+@onready var music_check_box: CheckBox = $MusicCheckBox
+
+@onready var sounds_label: Label = $SoundsLabel
+@onready var music_label: Label = $MusicLabel
+
+@onready var sounds_volume_label: Label = $SoundsVolumeLabel
+@onready var music_volume_label: Label = $MusicVolumeLabel
+
+@onready var sounds_volume_hslider: HSlider = $SoundsVolumeHSlider
+@onready var music_volume_hslider: HSlider = $MusicVolumeHSlider
+
+func _ready():
+	sounds_volume_label.text = "Volume: " + str(
+		round((sounds_volume_hslider.value))) + " / " + str(
+		round((sounds_volume_hslider.max_value)))
+	music_volume_label.text = "Volume: " + str(
+		round((music_volume_hslider.value))) + " / " + str(
+		round((music_volume_hslider.max_value)))
+	slider_access_handler()
+
+func _on_sounds_check_box_toggled(button_pressed):
+	var on_off_text = "ON" if button_pressed else "OFF"	
+	sounds_label.text = "Sound Effects: " + str(on_off_text)
+	slider_access_handler()
+
+func _on_music_check_box_toggled(button_pressed):
+	var on_off_text = "ON" if button_pressed else "OFF"
+	music_label.text = "Music: " + str(on_off_text)
+	slider_access_handler()
+
+func _on_sounds_volume_h_slider_value_changed(value):
+	sounds_volume_label.text = "Volume: " + str(round((value))) + " / " + str(
+		round((sounds_volume_hslider.max_value)))
+
+func _on_music_volume_h_slider_value_changed(value):
+	music_volume_label.text = "Volume: " + str(round((value))) + " / " + str(
+		round((music_volume_hslider.max_value)))
+
+
+func _on_back_to_main_menu_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/ui_menus/start_main_menu.tscn")
+
+func slider_access_handler():
+	sounds_volume_hslider.editable = true if sounds_check_box.button_pressed else false
+	sounds_volume_hslider.scrollable = true if sounds_check_box.button_pressed else false
+	music_volume_hslider.editable = true if music_check_box.button_pressed else false
+	music_volume_hslider.scrollable = true if music_check_box.button_pressed else false
+	if (not sounds_check_box.button_pressed):
+		_on_sounds_volume_h_slider_value_changed(0)
+		sounds_volume_hslider.value = 0
+	if (not music_check_box.button_pressed):
+		_on_music_volume_h_slider_value_changed(0)
+		music_volume_hslider.value = 0		
+	

--- a/Scripts/start_menu.gd
+++ b/Scripts/start_menu.gd
@@ -1,0 +1,8 @@
+extends Control
+
+func _on_start_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/main.tscn")
+
+
+func _on_options_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/ui_menus/options_main_menu.tscn")

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="MazeGen"
-run/main_scene="res://Scenes/main.tscn"
+run/main_scene="res://Scenes/ui_menus/start_main_menu.tscn"
 config/features=PackedStringArray("4.1", "GL Compatibility")
 config/icon="res://scripts/icon.svg"
 


### PR DESCRIPTION
+ Add ui_menus folder in scenes folder
+ Add start_main_menu scene (Handles the primary main menu of the game)
+ Add options_main_menu scene (Handles the option settings of the game)
+ Add start_menu.gd script
+ Atach start_menu.gd script to start_main_menu.tscn root scene node
+ Add optionS_main_menu.gd script
+ Attach options_main_menu.gd script to options_main_menu root scene node
+ Change project settings to now run the start_main_menu scene when the Run Project button is executed in godot