### PR TITLE
Add game over screen

### DIFF
--- a/Scenes/ui_menus/game_over.tscn
+++ b/Scenes/ui_menus/game_over.tscn
@@ -1,0 +1,95 @@
+[gd_scene load_steps=6 format=3 uid="uid://dxc84cgmhc20e"]
+
+[ext_resource type="Theme" uid="uid://buoyncyngk41t" path="res://Scenes/ui_menus/themes/accent_button.tres" id="1_07j6j"]
+[ext_resource type="Script" path="res://scripts/ui/game_over.gd" id="1_aromr"]
+[ext_resource type="Theme" uid="uid://c6ka6bijf8i7t" path="res://Scenes/ui_menus/themes/primary_button.tres" id="1_vh7s4"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_0hcd7"]
+font_size = 60
+font_color = Color(0.0392157, 0.12549, 0.184314, 1)
+outline_size = 12
+outline_color = Color(0.827451, 0.156863, 0.211765, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_wx3dw"]
+font_size = 28
+font_color = Color(0.529412, 0.109804, 0.243137, 1)
+
+[node name="GameOver" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_aromr")
+
+[node name="GameOverLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -163.5
+offset_top = 32.0
+offset_right = 163.5
+offset_bottom = 115.0
+grow_horizontal = 2
+text = "Game Over"
+label_settings = SubResource("LabelSettings_0hcd7")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="SpeechLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -280.0
+offset_top = -75.0
+offset_right = 280.0
+offset_bottom = 75.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "You didn't escape in time...
+Your fear consumed you. But don't worry, you can always try again..."
+label_settings = SubResource("LabelSettings_wx3dw")
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+
+[node name="BackToMenuButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -283.5
+offset_top = -133.0
+offset_right = -36.5
+offset_bottom = -80.0
+grow_horizontal = 2
+grow_vertical = 0
+theme = ExtResource("1_vh7s4")
+theme_override_font_sizes/font_size = 32
+text = "Go to the Menu"
+
+[node name="PlayAgainButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = 36.0
+offset_top = -132.0
+offset_right = 283.0
+offset_bottom = -79.0
+grow_horizontal = 2
+grow_vertical = 0
+theme = ExtResource("1_07j6j")
+text = "Go again"
+
+[connection signal="pressed" from="BackToMenuButton" to="." method="_on_back_to_menu_button_pressed"]
+[connection signal="pressed" from="PlayAgainButton" to="." method="_on_play_again_button_pressed"]

--- a/Scenes/ui_menus/themes/accent_button.tres
+++ b/Scenes/ui_menus/themes/accent_button.tres
@@ -1,0 +1,36 @@
+[gd_resource type="Theme" load_steps=4 format=3 uid="uid://buoyncyngk41t"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ovlsc"]
+bg_color = Color(0.827451, 0.156863, 0.211765, 1)
+border_width_bottom = 5
+border_color = Color(0.0392157, 0.12549, 0.184314, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3ox2t"]
+bg_color = Color(0.827451, 0.156863, 0.211765, 1)
+border_width_bottom = 5
+border_color = Color(0.188235, 0.176471, 0.415686, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4v60c"]
+bg_color = Color(0.529412, 0.109804, 0.243137, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[resource]
+Button/colors/font_color = Color(0.188235, 0.176471, 0.415686, 1)
+Button/colors/font_focus_color = Color(0.188235, 0.176471, 0.415686, 1)
+Button/colors/font_hover_color = Color(0.0392157, 0.12549, 0.184314, 1)
+Button/colors/font_pressed_color = Color(0.0392157, 0.12549, 0.184314, 1)
+Button/font_sizes/font_size = 32
+Button/styles/hover = SubResource("StyleBoxFlat_ovlsc")
+Button/styles/normal = SubResource("StyleBoxFlat_3ox2t")
+Button/styles/pressed = SubResource("StyleBoxFlat_4v60c")

--- a/Scenes/ui_menus/themes/primary_button.tres
+++ b/Scenes/ui_menus/themes/primary_button.tres
@@ -1,0 +1,36 @@
+[gd_resource type="Theme" load_steps=4 format=3 uid="uid://c6ka6bijf8i7t"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_o1cg6"]
+bg_color = Color(0.188235, 0.176471, 0.415686, 1)
+border_width_bottom = 5
+border_color = Color(0.827451, 0.156863, 0.211765, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jvavw"]
+bg_color = Color(0.188235, 0.176471, 0.415686, 1)
+border_width_bottom = 5
+border_color = Color(0.529412, 0.109804, 0.243137, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_sc5kj"]
+bg_color = Color(0.0392157, 0.12549, 0.184314, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[resource]
+Button/colors/font_color = Color(0.529412, 0.109804, 0.243137, 1)
+Button/colors/font_focus_color = Color(0.529412, 0.109804, 0.243137, 1)
+Button/colors/font_hover_color = Color(0.827451, 0.156863, 0.211765, 1)
+Button/colors/font_pressed_color = Color(0.827451, 0.156863, 0.211765, 1)
+Button/font_sizes/font_size = 32
+Button/styles/hover = SubResource("StyleBoxFlat_o1cg6")
+Button/styles/normal = SubResource("StyleBoxFlat_jvavw")
+Button/styles/pressed = SubResource("StyleBoxFlat_sc5kj")

--- a/Scripts/ui/game_over.gd
+++ b/Scripts/ui/game_over.gd
@@ -1,0 +1,8 @@
+extends Control
+
+func _on_back_to_menu_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/ui_menus/start_main_menu.tscn")
+
+
+func _on_play_again_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/main.tscn")


### PR DESCRIPTION
note that it currently is not connected to anything
- Add game_over.tscn scene
- Add game-_over.gd script and attach to game_over scene root node
- Add accent_button.tres button theme (styling theme for buttons, can be later used to easier apply or make changes to specific button theme and have it apply to all buttons that use the said theme, I recommend we make more of those for various ui elements, in order to create a more uniform styling throughout the game's gui elements)
- Add primary_button.tres button theme