### PR TITLE
Add gamemode selection menu

### DIFF
--- a/Scenes/ui_menus/gamemode_selection_button_group.tres
+++ b/Scenes/ui_menus/gamemode_selection_button_group.tres
@@ -1,4 +1,0 @@
-[gd_resource type="ButtonGroup" format=3 uid="uid://dmrm2b0elorvf"]
-
-[resource]
-allow_unpress = true

--- a/Scenes/ui_menus/gamemode_selection_button_group.tres
+++ b/Scenes/ui_menus/gamemode_selection_button_group.tres
@@ -1,0 +1,4 @@
+[gd_resource type="ButtonGroup" format=3 uid="uid://dmrm2b0elorvf"]
+
+[resource]
+allow_unpress = true

--- a/Scenes/ui_menus/gamemode_selection_main_menu.tscn
+++ b/Scenes/ui_menus/gamemode_selection_main_menu.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://ctcfvlkm46muh"]
+[gd_scene load_steps=4 format=3 uid="uid://ctcfvlkm46muh"]
 
 [ext_resource type="Script" path="res://scripts/ui/gamemode_selection_main_menu.gd" id="1_1gawi"]
-[ext_resource type="ButtonGroup" uid="uid://dmrm2b0elorvf" path="res://Scenes/ui_menus/gamemode_selection_button_group.tres" id="2_at5hj"]
-[ext_resource type="Theme" uid="uid://utp2ywxshuod" path="res://Scenes/ui_menus/themes/radio_button.tres" id="3_y6t2a"]
+[ext_resource type="Theme" uid="uid://hh87qw5s77n5" path="res://Scenes/ui_menus/themes/gamemode_selection_buttons.tres" id="3_po43m"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_otm70"]
 font_size = 48
@@ -15,7 +14,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_1gawi")
-group = ExtResource("2_at5hj")
 
 [node name="GamemodeLabel" type="Label" parent="."]
 layout_mode = 1
@@ -27,97 +25,75 @@ offset_top = 64.0
 offset_right = 135.0
 offset_bottom = 131.0
 grow_horizontal = 2
-text = "Gamemode"
+text = "You're playing with..."
 label_settings = SubResource("LabelSettings_otm70")
 
 [node name="MazephobiaButton" type="Button" parent="."]
+modulate = Color(1, 1, 1, 0.431373)
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
+anchors_preset = 4
 anchor_top = 0.5
-anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -100.0
-offset_top = -89.0
-offset_right = 100.0
-offset_bottom = -39.0
-grow_horizontal = 2
+offset_left = 96.0
+offset_top = -121.0
+offset_right = 596.0
+offset_bottom = -61.0
 grow_vertical = 2
-theme = ExtResource("3_y6t2a")
-toggle_mode = true
-button_group = ExtResource("2_at5hj")
+theme = ExtResource("3_po43m")
 text = "Mazephobia"
+alignment = 0
+text_overrun_behavior = 4
 
 [node name="DypraxiaButton" type="Button" parent="."]
+modulate = Color(1, 1, 1, 0.431373)
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
+anchors_preset = 4
 anchor_top = 0.5
-anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -100.0
+offset_left = 96.0
 offset_top = -26.5
-offset_right = 100.0
-offset_bottom = 26.5
-grow_horizontal = 2
+offset_right = 596.0
+offset_bottom = 33.5
 grow_vertical = 2
-theme = ExtResource("3_y6t2a")
-theme_override_font_sizes/font_size = 32
-toggle_mode = true
-button_group = ExtResource("2_at5hj")
+theme = ExtResource("3_po43m")
 text = "Dypraxia"
+alignment = 0
 
 [node name="HemiplagiaButton" type="Button" parent="."]
+modulate = Color(1, 1, 1, 0.431373)
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
+anchors_preset = 4
 anchor_top = 0.5
-anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -100.0
-offset_top = 37.5
-offset_right = 100.0
-offset_bottom = 90.5
-grow_horizontal = 2
+offset_left = 96.0
+offset_top = 69.5
+offset_right = 596.0
+offset_bottom = 129.5
 grow_vertical = 2
-theme = ExtResource("3_y6t2a")
-theme_override_font_sizes/font_size = 32
-toggle_mode = true
-button_group = ExtResource("2_at5hj")
+theme = ExtResource("3_po43m")
 text = "Hemiplagia"
-
-[node name="StartGameButton" type="Button" parent="."]
-layout_mode = 1
-anchors_preset = 7
-anchor_left = 0.5
-anchor_top = 1.0
-anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -4.0
-offset_top = -72.0
-offset_right = 4.0
-offset_bottom = -64.0
-grow_horizontal = 2
-grow_vertical = 0
-theme_override_font_sizes/font_size = 32
-disabled = true
-text = "Start Game"
+alignment = 0
 
 [node name="BackToMainMenuButton" type="Button" parent="."]
 layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_left = 128.0
-offset_top = -95.0
-offset_right = 288.0
+offset_left = 96.0
+offset_top = -111.0
+offset_right = 256.0
 offset_bottom = -64.0
 grow_vertical = 0
 theme_override_font_sizes/font_size = 28
 text = "Back"
 
-[connection signal="pressed" from="MazephobiaButton" to="." method="_on_gamemode_option_clicked"]
-[connection signal="pressed" from="DypraxiaButton" to="." method="_on_gamemode_option_clicked"]
-[connection signal="pressed" from="HemiplagiaButton" to="." method="_on_gamemode_option_clicked"]
-[connection signal="pressed" from="StartGameButton" to="." method="_on_start_game_button_pressed"]
+[connection signal="mouse_entered" from="MazephobiaButton" to="." method="_on_mouse_entered" binds= ["mazephobia"]]
+[connection signal="mouse_exited" from="MazephobiaButton" to="." method="_on_mouse_exited" binds= ["mazephobia"]]
+[connection signal="pressed" from="MazephobiaButton" to="." method="_on_gamemode_option_clicked" binds= ["mazephobia"]]
+[connection signal="mouse_entered" from="DypraxiaButton" to="." method="_on_mouse_entered" binds= ["dypraxia"]]
+[connection signal="mouse_exited" from="DypraxiaButton" to="." method="_on_mouse_exited" binds= ["dypraxia"]]
+[connection signal="pressed" from="DypraxiaButton" to="." method="_on_gamemode_option_clicked" binds= ["dypraxia"]]
+[connection signal="mouse_entered" from="HemiplagiaButton" to="." method="_on_mouse_entered" binds= ["hemiplagia"]]
+[connection signal="mouse_exited" from="HemiplagiaButton" to="." method="_on_mouse_exited" binds= ["hemiplagia"]]
+[connection signal="pressed" from="HemiplagiaButton" to="." method="_on_gamemode_option_clicked" binds= ["hemiplagia"]]
 [connection signal="pressed" from="BackToMainMenuButton" to="." method="_on_back_to_main_menu_button_pressed"]

--- a/Scenes/ui_menus/gamemode_selection_main_menu.tscn
+++ b/Scenes/ui_menus/gamemode_selection_main_menu.tscn
@@ -1,0 +1,123 @@
+[gd_scene load_steps=5 format=3 uid="uid://ctcfvlkm46muh"]
+
+[ext_resource type="Script" path="res://scripts/ui/gamemode_selection_main_menu.gd" id="1_1gawi"]
+[ext_resource type="ButtonGroup" uid="uid://dmrm2b0elorvf" path="res://Scenes/ui_menus/gamemode_selection_button_group.tres" id="2_at5hj"]
+[ext_resource type="Theme" uid="uid://utp2ywxshuod" path="res://Scenes/ui_menus/themes/radio_button.tres" id="3_y6t2a"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_otm70"]
+font_size = 48
+
+[node name="GamemodeSelection" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_1gawi")
+group = ExtResource("2_at5hj")
+
+[node name="GamemodeLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -135.0
+offset_top = 64.0
+offset_right = 135.0
+offset_bottom = 131.0
+grow_horizontal = 2
+text = "Gamemode"
+label_settings = SubResource("LabelSettings_otm70")
+
+[node name="MazephobiaButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -89.0
+offset_right = 100.0
+offset_bottom = -39.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("3_y6t2a")
+toggle_mode = true
+button_group = ExtResource("2_at5hj")
+text = "Mazephobia"
+
+[node name="DypraxiaButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -26.5
+offset_right = 100.0
+offset_bottom = 26.5
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("3_y6t2a")
+theme_override_font_sizes/font_size = 32
+toggle_mode = true
+button_group = ExtResource("2_at5hj")
+text = "Dypraxia"
+
+[node name="HemiplagiaButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = 37.5
+offset_right = 100.0
+offset_bottom = 90.5
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("3_y6t2a")
+theme_override_font_sizes/font_size = 32
+toggle_mode = true
+button_group = ExtResource("2_at5hj")
+text = "Hemiplagia"
+
+[node name="StartGameButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -4.0
+offset_top = -72.0
+offset_right = 4.0
+offset_bottom = -64.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_font_sizes/font_size = 32
+disabled = true
+text = "Start Game"
+
+[node name="BackToMainMenuButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 128.0
+offset_top = -95.0
+offset_right = 288.0
+offset_bottom = -64.0
+grow_vertical = 0
+theme_override_font_sizes/font_size = 28
+text = "Back"
+
+[connection signal="pressed" from="MazephobiaButton" to="." method="_on_gamemode_option_clicked"]
+[connection signal="pressed" from="DypraxiaButton" to="." method="_on_gamemode_option_clicked"]
+[connection signal="pressed" from="HemiplagiaButton" to="." method="_on_gamemode_option_clicked"]
+[connection signal="pressed" from="StartGameButton" to="." method="_on_start_game_button_pressed"]
+[connection signal="pressed" from="BackToMainMenuButton" to="." method="_on_back_to_main_menu_button_pressed"]

--- a/Scenes/ui_menus/themes/gamemode_selection_buttons.tres
+++ b/Scenes/ui_menus/themes/gamemode_selection_buttons.tres
@@ -1,0 +1,42 @@
+[gd_resource type="Theme" load_steps=4 format=3 uid="uid://hh87qw5s77n5"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_25hfb"]
+content_margin_left = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 6.0
+bg_color = Color(0.0392157, 0.12549, 0.184314, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.827451, 0.156863, 0.211765, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qhdj8"]
+content_margin_left = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 6.0
+bg_color = Color(0.0392157, 0.12549, 0.184314, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.827451, 0.156863, 0.211765, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ha4ac"]
+content_margin_left = 10.0
+content_margin_right = 10.0
+bg_color = Color(0.0392157, 0.12549, 0.184314, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.827451, 0.156863, 0.211765, 1)
+
+[resource]
+Button/colors/font_color = Color(0.827451, 0.156863, 0.211765, 1)
+Button/colors/font_hover_color = Color(0.827451, 0.156863, 0.211765, 1)
+Button/colors/font_pressed_color = Color(0.827451, 0.156863, 0.211765, 1)
+Button/font_sizes/font_size = 20
+Button/styles/hover = SubResource("StyleBoxFlat_25hfb")
+Button/styles/normal = SubResource("StyleBoxFlat_qhdj8")
+Button/styles/pressed = SubResource("StyleBoxFlat_ha4ac")

--- a/Scenes/ui_menus/themes/radio_button.tres
+++ b/Scenes/ui_menus/themes/radio_button.tres
@@ -1,0 +1,35 @@
+[gd_resource type="Theme" load_steps=4 format=3 uid="uid://utp2ywxshuod"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_25hfb"]
+bg_color = Color(0.188235, 0.176471, 0.415686, 1)
+border_width_bottom = 5
+border_color = Color(0.0392157, 0.12549, 0.184314, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qhdj8"]
+bg_color = Color(0.188235, 0.176471, 0.415686, 1)
+border_width_bottom = 5
+border_color = Color(0.0392157, 0.12549, 0.184314, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ha4ac"]
+bg_color = Color(0.529412, 0.109804, 0.243137, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[resource]
+Button/colors/font_color = Color(0.529412, 0.109804, 0.243137, 1)
+Button/colors/font_hover_color = Color(0.827451, 0.156863, 0.211765, 1)
+Button/colors/font_pressed_color = Color(0.0392157, 0.12549, 0.184314, 1)
+Button/font_sizes/font_size = 32
+Button/styles/hover = SubResource("StyleBoxFlat_25hfb")
+Button/styles/normal = SubResource("StyleBoxFlat_qhdj8")
+Button/styles/pressed = SubResource("StyleBoxFlat_ha4ac")

--- a/Scenes/ui_menus/themes/radio_button.tres
+++ b/Scenes/ui_menus/themes/radio_button.tres
@@ -1,6 +1,8 @@
 [gd_resource type="Theme" load_steps=4 format=3 uid="uid://utp2ywxshuod"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_25hfb"]
+content_margin_left = 10.0
+content_margin_right = 10.0
 bg_color = Color(0.188235, 0.176471, 0.415686, 1)
 border_width_bottom = 5
 border_color = Color(0.0392157, 0.12549, 0.184314, 1)
@@ -10,6 +12,8 @@ corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qhdj8"]
+content_margin_left = 10.0
+content_margin_right = 10.0
 bg_color = Color(0.188235, 0.176471, 0.415686, 1)
 border_width_bottom = 5
 border_color = Color(0.0392157, 0.12549, 0.184314, 1)
@@ -19,6 +23,8 @@ corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ha4ac"]
+content_margin_left = 10.0
+content_margin_right = 10.0
 bg_color = Color(0.529412, 0.109804, 0.243137, 1)
 corner_radius_top_left = 6
 corner_radius_top_right = 6
@@ -29,7 +35,7 @@ corner_radius_bottom_left = 6
 Button/colors/font_color = Color(0.529412, 0.109804, 0.243137, 1)
 Button/colors/font_hover_color = Color(0.827451, 0.156863, 0.211765, 1)
 Button/colors/font_pressed_color = Color(0.0392157, 0.12549, 0.184314, 1)
-Button/font_sizes/font_size = 32
+Button/font_sizes/font_size = 20
 Button/styles/hover = SubResource("StyleBoxFlat_25hfb")
 Button/styles/normal = SubResource("StyleBoxFlat_qhdj8")
 Button/styles/pressed = SubResource("StyleBoxFlat_ha4ac")

--- a/Scripts/Globals.gd
+++ b/Scripts/Globals.gd
@@ -6,4 +6,8 @@ var allow_loops = false
 var letters_to_show = []
 var show_labels = false
 
+var gamemode = ""
+var sfx_volume = 0
+var music_volume = 0
+
 signal fringe_changed

--- a/Scripts/start_menu.gd
+++ b/Scripts/start_menu.gd
@@ -1,7 +1,7 @@
 extends Control
 
 func _on_start_button_pressed():
-	get_tree().change_scene_to_file("res://Scenes/main.tscn")
+	get_tree().change_scene_to_file("res://Scenes/ui_menus/gamemode_selection_main_menu.tscn")
 
 
 func _on_options_button_pressed():

--- a/Scripts/ui/gamemode_selection_main_menu.gd
+++ b/Scripts/ui/gamemode_selection_main_menu.gd
@@ -1,40 +1,52 @@
 extends Control
 
-@export var group: ButtonGroup
+@export_range(0, 1.5) var opacity_up_time = 0.2
+@export_range(0, 1.5) var opacity_down_time = 0.3
+@export_range(0, 255) var opacity_down = 110
 
 @onready var mazephobia_button: Button = $MazephobiaButton
 @onready var dypraxia_button: Button = $DypraxiaButton
 @onready var hemiplagia_button: Button = $HemiplagiaButton
-@onready var start_game_button: Button = $StartGameButton
-
-var selected_option: String = ""
 
 func _ready():
 	if (Globals.gamemode != ""):
 		Globals.gamemode = ""
 
-func _on_gamemode_option_clicked():
-	match group.get_pressed_button():
-		mazephobia_button:
-			selected_option = "mazephobia"
-			start_button_active(true)
-		dypraxia_button:
-			selected_option = "dypraxia"
-			start_button_active(true)
-		hemiplagia_button:
-			selected_option = "hemiplagia"
-			start_button_active(true)
-		_:
-			selected_option = ""
-			start_button_active(false)
+func _on_mouse_entered(mode):
+	match mode:
+		"mazephobia":	tween_opacity_up(mazephobia_button, "mazephobia")
+		"dypraxia":	tween_opacity_up(dypraxia_button, "dypraxia")
+		"hemiplagia":	tween_opacity_up(hemiplagia_button, "hemiplagia")
 
-func start_button_active(value: bool):
-	start_game_button.disabled = not value
 
-func _on_start_game_button_pressed():
-	Globals.gamemode = selected_option
+func _on_mouse_exited(mode):
+	match mode:
+		"mazephobia":	tween_opacity_down(mazephobia_button, "mazephobia")
+		"dypraxia":	tween_opacity_down(dypraxia_button, "dypraxia")
+		"hemiplagia":	tween_opacity_down(hemiplagia_button, "hemiplagia")
+
+
+func tween_opacity_up(button: Button, mode):
+	var tween: Tween = create_tween()
+	tween.tween_property(button, "modulate",
+		Color(button.modulate.r, button.modulate.g, button.modulate.b, 1),
+		opacity_up_time)
+
+func tween_opacity_down(button: Button, mode):
+	var tween: Tween = create_tween()
+	tween.tween_property(button, "modulate",
+		Color(button.modulate.r, button.modulate.g, button.modulate.b, (1.0 / 255) * opacity_down),
+		opacity_down_time)
+
+func _on_gamemode_option_clicked(mode):
+	match mode:
+		"mazephobia":	set_gamemode("mazephobia")
+		"dypraxia":	set_gamemode("dypraxia")
+		"hemiplagia":	set_gamemode("hemiplagia")
+
+func set_gamemode(gamemode_value):
+	Globals.gamemode = gamemode_value
 	get_tree().change_scene_to_file("res://Scenes/main.tscn")
-
 
 func _on_back_to_main_menu_button_pressed():
 	get_tree().change_scene_to_file("res://Scenes/ui_menus/start_main_menu.tscn")

--- a/Scripts/ui/gamemode_selection_main_menu.gd
+++ b/Scripts/ui/gamemode_selection_main_menu.gd
@@ -1,0 +1,40 @@
+extends Control
+
+@export var group: ButtonGroup
+
+@onready var mazephobia_button: Button = $MazephobiaButton
+@onready var dypraxia_button: Button = $DypraxiaButton
+@onready var hemiplagia_button: Button = $HemiplagiaButton
+@onready var start_game_button: Button = $StartGameButton
+
+var selected_option: String = ""
+
+func _ready():
+	if (Globals.gamemode != ""):
+		Globals.gamemode = ""
+
+func _on_gamemode_option_clicked():
+	match group.get_pressed_button():
+		mazephobia_button:
+			selected_option = "mazephobia"
+			start_button_active(true)
+		dypraxia_button:
+			selected_option = "dypraxia"
+			start_button_active(true)
+		hemiplagia_button:
+			selected_option = "hemiplagia"
+			start_button_active(true)
+		_:
+			selected_option = ""
+			start_button_active(false)
+
+func start_button_active(value: bool):
+	start_game_button.disabled = not value
+
+func _on_start_game_button_pressed():
+	Globals.gamemode = selected_option
+	get_tree().change_scene_to_file("res://Scenes/main.tscn")
+
+
+func _on_back_to_main_menu_button_pressed():
+	get_tree().change_scene_to_file("res://Scenes/ui_menus/start_main_menu.tscn")


### PR DESCRIPTION
- Add gamemode_selection_main_menu_tscn scene
- Add gamemode_selection_main_menu.gd script and attach it to the root node of gamemode_selection_main_menu.tscn scene
- Add gamemode_selection_button_group.tres ButtonGroup resource for the gamemode selection buttons
- Add radio_button.tres button theme
- Change Globals.gd script by adding a few new fields for later use
- Change start_menu.gd by making the signal function of the StartGameButton now change to the gamemode_selection_main_menu.tscn scene instead of main.tscn scene